### PR TITLE
cli/ls: sort entries just before listing (after filtering)

### DIFF
--- a/cli/ls.c
+++ b/cli/ls.c
@@ -368,9 +368,6 @@ static int ls(struct cmdctx *cmdctx)
         goto l_end;
     }
 
-    if ((cmpf = select_cmpf(cmdctx->_flags)))
-         n_array_sort_ex(ls_ents, cmpf);
-
     if (cmdctx->_flags & OPT_LS_UPGRADEABLE) {
         tn_array *tmp;
 
@@ -386,6 +383,9 @@ static int ls(struct cmdctx *cmdctx)
     }
 
     if (n_array_size(ls_ents)) {
+        if ((cmpf = select_cmpf(cmdctx->_flags)))
+            n_array_sort_ex(ls_ents, cmpf);
+
         rc = do_ls(ls_ents, cmdctx, evrs);
 
         if (cmpf)


### PR DESCRIPTION
fixes global entries order being broken after doing `ls -ut`.
"upgradable" listing overrides `ls_ents` and hence sort order
restoration operates on wrong array. observed broken beavior:

- invoking:
  (1) ls -u
  (2) ls -ut
  (3) ls -u

  should result in (1) and (3) being the same while in fact (2) and (3)
  are the same

- after invoking `ls -ut` package name completion is broken since it
  uses binary search and therefore relies on correct order

also doing `ls -u` might get marginally faster since it no longer needs
to sort all available packages, but only those which are upgradable.